### PR TITLE
-Werror breaks build on base >= 4.8 (ghc >= 7.10) due to: The import of ‘Control.Applicative’ is redundant

### DIFF
--- a/os-release.cabal
+++ b/os-release.cabal
@@ -47,7 +47,6 @@ test-suite tests
         Haskell2010
     ghc-options:
         -Wall
-        -Werror
     hs-source-dirs:
         library
         tests/unit


### PR DESCRIPTION
Since GHC 7.10 (actually base 4.8) there is a warning

```
library/System/OsRelease.hs:22:1: Warning:
    The import of ‘Control.Applicative’ is redundant
      except perhaps to import instances from ‘Control.Applicative’
    To import instances alone, use: import Control.Applicative()
```

due to <$> being exported by Prelude. This would make the compilation fail with -Werror enabled.

I did the simplest possible thing to enable successful compilation under GHC 7.10, namely to remove the -Werror option when building the test suite. An alternative would be to use CPP and conditionals but that makes ghci and hlint a bit tricky to deal with. Another alternative would be to replace the use of `<$>` with `fmap` but I noticed that then hlint complains and suggest using `<$>`. So I went for the simplest solution and will let you decide which you prefer :-)
